### PR TITLE
resultとquestionモデルを作成

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,9 @@
+class Question < ApplicationRecord
+  belongs_to :trouble
+  belongs_to :result
+
+  with_options presence: true do
+    validates :content
+    validates :point
+  end
+end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,3 +1,5 @@
 class Result < ApplicationRecord
+  has_many :questions, dependent: :restrict_with_error
+
   validates :content, presence: true
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,0 +1,3 @@
+class Result < ApplicationRecord
+  validates :content, presence: true
+end

--- a/app/models/trouble.rb
+++ b/app/models/trouble.rb
@@ -1,3 +1,5 @@
 class Trouble < ApplicationRecord
+  has_many :questions, dependent: :restrict_with_error
+
   validates :content, presence: true
 end

--- a/db/fixtures/question.rb
+++ b/db/fixtures/question.rb
@@ -1,0 +1,59 @@
+# 困り事：買うか迷い中、診断結果：買う
+buy_questions = {
+  '1年後も使っていることを想像できますか': '買った後のことを考えることが大事',
+  '悩んでいる理由は、値段が高いからだけですか': '悩む理由が値段なら買ったほうが良いサイン'
+}
+
+# 困り事：買うか迷い中、診断結果：買わない
+not_buy_questions = {
+  '迷っている商品は、希少品か限定品ですか': '商品の希少性に惹かれてるだけの可能性が高い',
+  '予算オーバーしてますか': '予算オーバーしてるなら買わない方が良い'
+}
+
+# 困り事：小腹を満たすか迷い中、診断結果：食べる
+eat_questions = {
+  '太るとお相撲さんになるからですか': '横綱は稼げる',
+  '太るとモテなくなるからですか': 'デブ専にモテる'
+}
+
+# 困り事：小腹を満たすか迷い中、診断結果：食べない
+not_eat_questions = {
+  '健康な生活を送りたいからですか': '太ることによる最大のデメリットは健康を害すること',
+  '今ある服を着れなくなるからですか': '服を買い換えるのは余計な手間と出費になる'
+}
+
+buy_questions.each do |content, point|
+  Question.seed(:content) do |q|
+    q.content = content
+    q.point = point
+    q.trouble_id = 1
+    q.result_id = 1
+  end
+end
+
+not_buy_questions.each do |content, point|
+  Question.seed(:content) do |q|
+    q.content = content
+    q.point = point
+    q.trouble_id = 1
+    q.result_id = 2
+  end
+end
+
+eat_questions.each do |content, point|
+  Question.seed(:content) do |q|
+    q.content = content
+    q.point = point
+    q.trouble_id = 2
+    q.result_id = 3
+  end
+end
+
+not_eat_questions.each do |content, point|
+  Question.seed(:content) do |q|
+    q.content = content
+    q.point = point
+    q.trouble_id = 2
+    q.result_id = 4
+  end
+end

--- a/db/fixtures/result.rb
+++ b/db/fixtures/result.rb
@@ -1,0 +1,6 @@
+Result.seed(
+  { id: 1, content: '買う' },
+  { id: 2, content: '買わない' },
+  { id: 3, content: '食べる' },
+  { id: 4, content: '食べない' }
+)

--- a/db/migrate/20220407015003_create_results.rb
+++ b/db/migrate/20220407015003_create_results.rb
@@ -1,0 +1,9 @@
+class CreateResults < ActiveRecord::Migration[6.1]
+  def change
+    create_table :results do |t|
+      t.string :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220407021225_create_questions.rb
+++ b/db/migrate/20220407021225_create_questions.rb
@@ -1,0 +1,12 @@
+class CreateQuestions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :questions do |t|
+      t.string :content, null: false
+      t.string :point, null: false
+      t.references :trouble, foreign_key: true
+      t.references :result, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_07_015003) do
+ActiveRecord::Schema.define(version: 2022_04_07_021225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "questions", force: :cascade do |t|
+    t.string "content", null: false
+    t.string "point", null: false
+    t.bigint "trouble_id"
+    t.bigint "result_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["result_id"], name: "index_questions_on_result_id"
+    t.index ["trouble_id"], name: "index_questions_on_trouble_id"
+  end
 
   create_table "results", force: :cascade do |t|
     t.string "content", null: false
@@ -27,4 +38,6 @@ ActiveRecord::Schema.define(version: 2022_04_07_015003) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "questions", "results"
+  add_foreign_key "questions", "troubles"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_05_131408) do
+ActiveRecord::Schema.define(version: 2022_04_07_015003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "results", force: :cascade do |t|
+    t.string "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "troubles", force: :cascade do |t|
     t.string "content", null: false


### PR DESCRIPTION
## 概要

- resultsとquestionsテーブルを作成し、それぞれ初期データを追加。

## コメント

- resultとtroubleモデルに以下を追加。親テーブルのレコード削除時、関連付けされているレコードが存在すると、削除を引き留めるよう設定。
```
has_many :questions, dependent: :restrict_with_error
```

- questionsテーブルの初期データは、開発中質問を全て出題したときの挙動も確認するため少なめにしています。